### PR TITLE
hold onto base case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 database_specs.csv
 output/
 data/
+dev/

--- a/R/apop.R
+++ b/R/apop.R
@@ -16,30 +16,30 @@ apop <- function(lpop, agedat, strata){
                                                    sex == 'females' ~ 2,
                                                    TRUE ~ 3)) %>%
     tidytable::rename.(sizepop = value) -> .lpop_long
-
+  
   # compute resampled age pop'n for females & males
   if(isTRUE(strata)) {
     agedat %>%
       tidytable::drop_na.() %>%
       tidytable::summarise.(age_num = .N, 
-                            .by = c(year, species_code, stratum, sex, length, age)) %>% 
+                            .by = c(year, species_code, stratum, sex, length, age, type)) %>% 
       tidytable::mutate.(age_frac = age_num/sum(age_num), 
-                         .by = c(year, species_code, stratum, sex, length)) %>% 
+                         .by = c(year, species_code, stratum, sex, length, type)) %>% 
       tidytable::left_join.(.lpop_long) %>%
       tidytable::drop_na.() %>% 
       tidytable::mutate.(agepop = age_frac * sizepop, 
-                         .by = c(year, species_code, stratum, sex, length)) %>%
+                         .by = c(year, species_code, stratum, sex, length, type)) %>%
       tidytable::mutate.(agepop = sum(agepop), 
-                         .by = c(year, species_code, stratum, sex, age)) %>%
-      tidytable::select.(year, species_code, sex, stratum, age, agepop) %>%
-      unique(., by = c('year', 'species_code', 'sex', 'age', 'agepop')) %>% 
+                         .by = c(year, species_code, stratum, sex, age, type)) %>%
+      tidytable::select.(year, species_code, sex, stratum, age, agepop, type) %>%
+      unique(., by = c('year', 'species_code', 'sex', 'age', 'agepop', 'type')) %>% 
       tidytable::filter.(sex != 3) -> .agepop_mf
     
     # compute resampled age pop'n for unsexed (og rule is if you have a year with unsexed specimen data you use all the specimen data)
     agedat %>%
       tidytable::drop_na.() %>% 
       tidytable::summarise.(n = .N, 
-                            .by = c('year', 'species_code', 'sex')) %>%
+                            .by = c('year', 'species_code', 'sex', 'type')) %>%
       tidytable::filter.(sex == 3) %>%
       tidytable::select.(year, species_code, n) -> .sex_cnt_ag
     
@@ -50,17 +50,17 @@ apop <- function(lpop, agedat, strata){
       agedat %>%
         tidytable::left_join.(.sex_cnt_ag) %>%
         tidytable::filter.(n > 0) %>%
-        tidytable::summarise.(age_num = .N, .by = c(year, species_code, stratum, length, age)) %>% 
+        tidytable::summarise.(age_num = .N, .by = c(year, species_code, stratum, length, age, type)) %>% 
         tidytable::mutate.(age_frac = age_num/sum(age_num), 
-                           .by = c(year, species_code, stratum, length)) %>%
+                           .by = c(year, species_code, stratum, length, type)) %>%
         tidytable::left_join.(.lpop_long_un) %>%
         tidytable::drop_na.() %>% 
         tidytable::mutate.(agepop = age_frac * sizepop, 
-                           .by = c(year, species_code, stratum, length)) %>%
+                           .by = c(year, species_code, stratum, length, type)) %>%
         tidytable::mutate.(agepop = sum(agepop), 
-                           .by = c(year, species_code, stratum, age)) %>%
-        tidytable::select.(year, species_code, stratum, sex, age, agepop) %>% 
-        unique(., by = c('year', 'species_code', 'stratum', 'sex', 'age', 'agepop')) %>%
+                           .by = c(year, species_code, stratum, age, type)) %>%
+        tidytable::select.(year, species_code, stratum, sex, age, agepop, type) %>% 
+        unique(., by = c('year', 'species_code', 'stratum', 'sex', 'age', 'agepop', 'type')) %>%
         tidytable::select.(-c(length, age_num, age_frac, sizepop)) %>% 
         tidytable::bind_rows.(.agepop_mf) %>%
         tidytable::pivot_wider.(names_from = sex, values_from = agepop, values_fill = 0) %>%
@@ -72,55 +72,55 @@ apop <- function(lpop, agedat, strata){
         tidytable::mutate.(unsexed = 0) 
     }
   } else {
-  agedat %>%
-    tidytable::drop_na.() %>%
-    tidytable::summarise.(age_num = .N, .by = c(year, species_code, sex, length, age)) %>% 
-    tidytable::mutate.(age_frac = age_num/sum(age_num), 
-                       .by = c(year, species_code, sex, length)) %>% 
-    tidytable::left_join.(.lpop_long) %>%
-    tidytable::drop_na.() %>% 
-    tidytable::mutate.(agepop = age_frac * sizepop, 
-                       .by = c(year, species_code, sex, length)) %>%
-    tidytable::mutate.(agepop = sum(agepop), 
-                       .by = c(year, species_code, sex, age)) %>%
-    tidytable::select.(year, species_code, sex, age, agepop) %>%
-    unique(., by = c('year', 'species_code', 'sex', 'age', 'agepop')) %>% 
-    tidytable::filter.(sex != 3) -> .agepop_mf
-  
-  # compute resampled age pop'n for unsexed (og rule is if you have a year with unsexed specimen data you use all the specimen data)
-  agedat %>%
-    tidytable::drop_na.() %>% 
-    tidytable::summarise.(n = .N, .by = c('year', 'species_code', 'sex')) %>%
-    tidytable::filter.(sex == 3) %>%
-    tidytable::select.(year, species_code, n) -> .sex_cnt_ag
-  
-  if(length(.sex_cnt_ag$n)>0){
-    .lpop_long %>%
-      tidytable::filter.(sex == 3) -> .lpop_long_un
-    
     agedat %>%
-      tidytable::left_join.(.sex_cnt_ag) %>%
-      tidytable::filter.(n > 0) %>%
-      tidytable::summarise.(age_num = .N, .by = c(year, species_code, length, age)) %>% 
+      tidytable::drop_na.() %>%
+      tidytable::summarise.(age_num = .N, .by = c(year, species_code, sex, length, age, type)) %>% 
       tidytable::mutate.(age_frac = age_num/sum(age_num), 
-                         .by = c(year, species_code, length)) %>%
-      tidytable::left_join.(.lpop_long_un) %>%
+                         .by = c(year, species_code, sex, length, type)) %>% 
+      tidytable::left_join.(.lpop_long) %>%
       tidytable::drop_na.() %>% 
       tidytable::mutate.(agepop = age_frac * sizepop, 
-                         .by = c(year, species_code, length)) %>%
+                         .by = c(year, species_code, sex, length, type)) %>%
       tidytable::mutate.(agepop = sum(agepop), 
-                         .by = c(year, species_code, age)) %>%
-      unique(., by = c('year', 'species_code', 'sex', 'age', 'agepop')) %>%
-      tidytable::select.(-c(length, age_num, age_frac, sizepop)) %>% 
-      tidytable::bind_rows.(.agepop_mf) %>%
-      tidytable::pivot_wider.(names_from = sex, values_from = agepop, values_fill = 0) %>%
-      tidytable::rename.(unsexed = '3', males = '1', females = '2') 
-  } else{
-    .agepop_mf %>%
-      tidytable::pivot_wider.(names_from = sex, values_from = agepop, values_fill = 0) %>%
-      tidytable::rename.(males = '1', females = '2') %>%
-      tidytable::mutate.(unsexed = 0) 
-  }
-  
+                         .by = c(year, species_code, sex, age, type)) %>%
+      tidytable::select.(year, species_code, sex, age, agepop, type) %>%
+      unique(., by = c('year', 'species_code', 'sex', 'age', 'agepop', 'type')) %>% 
+      tidytable::filter.(sex != 3) -> .agepop_mf
+    
+    # compute resampled age pop'n for unsexed (og rule is if you have a year with unsexed specimen data you use all the specimen data)
+    agedat %>%
+      tidytable::drop_na.() %>% 
+      tidytable::summarise.(n = .N, .by = c('year', 'species_code', 'sex', 'type')) %>%
+      tidytable::filter.(sex == 3) %>%
+      tidytable::select.(year, species_code, n) -> .sex_cnt_ag
+    
+    if(length(.sex_cnt_ag$n)>0){
+      .lpop_long %>%
+        tidytable::filter.(sex == 3) -> .lpop_long_un
+      
+      agedat %>%
+        tidytable::left_join.(.sex_cnt_ag) %>%
+        tidytable::filter.(n > 0) %>%
+        tidytable::summarise.(age_num = .N, .by = c(year, species_code, length, age, type)) %>% 
+        tidytable::mutate.(age_frac = age_num/sum(age_num), 
+                           .by = c(year, species_code, length, type)) %>%
+        tidytable::left_join.(.lpop_long_un) %>%
+        tidytable::drop_na.() %>% 
+        tidytable::mutate.(agepop = age_frac * sizepop, 
+                           .by = c(year, species_code, length, type)) %>%
+        tidytable::mutate.(agepop = sum(agepop), 
+                           .by = c(year, species_code, age, type)) %>%
+        unique(., by = c('year', 'species_code', 'sex', 'age', 'agepop', 'type')) %>%
+        tidytable::select.(-c(length, age_num, age_frac, sizepop)) %>% 
+        tidytable::bind_rows.(.agepop_mf) %>%
+        tidytable::pivot_wider.(names_from = sex, values_from = agepop, values_fill = 0) %>%
+        tidytable::rename.(unsexed = '3', males = '1', females = '2') 
+    } else{
+      .agepop_mf %>%
+        tidytable::pivot_wider.(names_from = sex, values_from = agepop, values_fill = 0) %>%
+        tidytable::rename.(males = '1', females = '2') %>%
+        tidytable::mutate.(unsexed = 0) 
+    }
+    
   }
 }

--- a/R/ess_age.R
+++ b/R/ess_age.R
@@ -2,47 +2,13 @@
 #'
 #' @param sim_data list of abundance by age data
 #' @param og_data original abundance by age data (single list)
-#' @param strata switch to perform analysis at regional or strata level (default = NULL)
 #'
 #' @return
 #' @export
 #'
 #' @examples
-ess_age <- function(sim_data, og_data, strata){
+ess_age <- function(sim_data, og_data){
   
-  if ("stratum" %in% names(og_data) & isFALSE(strata) |
-      "stratum" %in% names(sim_data) & isFALSE(strata)) {
-    stop("check your strata")
-  }
-  
-  if (isTRUE(strata)) {
-   og_data %>% 
-    tidytable::rename.('og_unsexed' = unsexed,
-                       'og_males' = males,
-                       'og_females' = females) %>% 
-    tidytable::mutate.(og_total = og_unsexed + og_males + og_females) -> og
-  
-  sim_data %>% 
-    tidytable::mutate.(total = unsexed + males + females) %>% 
-    tidytable::full_join.(og) %>% 
-    tidytable::replace_na(list(og_unsexed = 0, og_males = 0, og_females = 0, og_total = 0, 
-                               unsexed = 0, males = 0, females = 0, total = 0)) %>%
-    tidytable::mutate.(og_m = og_males / sum(og_males),
-                       og_f = og_females / sum(og_females),
-                       og_t = og_total/sum(og_total),
-                       prop_m = males / sum(males),
-                       prop_f = females / sum(females),
-                       prop_t = total/sum(total),
-                       .by = c(year, species_code, stratum)) %>% 
-    tidytable::mutate.(ess_f = sum(prop_f * (1 - prop_f)) / sum((prop_f - og_f)^2),
-                       ess_m = sum(prop_m * (1 - prop_m)) / sum((prop_m - og_m)^2),
-                       ess_t = sum(prop_t * (1 - prop_t)) / sum((prop_t - og_t)^2),
-                       .by = c(year, species_code, stratum)) %>%
-    tidytable::select.(year, species_code, stratum, age, ess_f, ess_m, ess_t) %>% 
-    tidytable::pivot_longer.(cols = c(ess_f, ess_m, ess_t), names_to = "ess") %>%
-    tidytable::distinct(year, species_code, stratum, ess, value) 
-    
-  } else {
   og_data %>% 
     tidytable::rename.('og_unsexed' = unsexed,
                        'og_males' = males,
@@ -52,6 +18,7 @@ ess_age <- function(sim_data, og_data, strata){
   sim_data %>% 
     tidytable::mutate.(total = unsexed + males + females) %>% 
     tidytable::full_join.(og) %>% 
+    tidytable::drop_na() %>% 
     tidytable::replace_na(list(og_unsexed = 0, og_males = 0, og_females = 0, og_total = 0, 
                                unsexed = 0, males = 0, females = 0, total = 0)) %>%
     tidytable::mutate.(og_m = og_males / sum(og_males),
@@ -60,14 +27,13 @@ ess_age <- function(sim_data, og_data, strata){
                        prop_m = males / sum(males),
                        prop_f = females / sum(females),
                        prop_t = total/sum(total),
-                       .by = c(year, species_code)) %>% 
+                       .by = c(year, species_code, type)) %>% 
     tidytable::mutate.(ess_f = sum(prop_f * (1 - prop_f)) / sum((prop_f - og_f)^2),
                        ess_m = sum(prop_m * (1 - prop_m)) / sum((prop_m - og_m)^2),
                        ess_t = sum(prop_t * (1 - prop_t)) / sum((prop_t - og_t)^2),
-                       .by = c(year, species_code)) %>%
-    tidytable::select.(year, species_code, age, ess_f, ess_m, ess_t) %>% 
+                       .by = c(year, species_code, type)) %>%
+    tidytable::select.(year, species_code, type, age, ess_f, ess_m, ess_t) %>% 
     tidytable::pivot_longer.(cols = c(ess_f, ess_m, ess_t), names_to = "ess") %>%
-    tidytable::distinct(year, species_code, ess, value) 
-  }
+    tidytable::distinct(year, species_code, type, ess, value) 
   
 }

--- a/R/ess_size.R
+++ b/R/ess_size.R
@@ -2,68 +2,37 @@
 #'
 #' @param sim_data list of abundance by length data
 #' @param og_data original abundance by length data (single list)
-#' @param strata switch to perform analysis at regional or strata level (default = NULL)
 #'
 #' @return
 #' @export
 #'
 #' @examples
-ess_size <- function(sim_data, og_data, strata) {
+ess_size <- function(sim_data, og_data) {
   
-  if ("stratum" %in% names(og_data) & isFALSE(strata) |
-      "stratum" %in% names(sim_data) & isFALSE(strata)) {
-    stop("check your strata")
-  }
-  
-    og_data %>% 
+  og_data %>% 
     tidytable::rename.('og_unsexed' = unsexed,
                        'og_males' = males,
                        'og_females' = females) %>% 
     tidytable::mutate.(og_total = og_unsexed + og_males + og_females) -> og
-
-  if (isTRUE(strata)) {
-    sim_data %>% 
-        tidytable::mutate.(total = unsexed + males + females) %>% 
-        tidytable::full_join.(og) %>% 
-        tidytable::replace_na(list(og_unsexed = 0, og_males = 0, og_females = 0, og_total = 0, 
-                                  unsexed = 0, males = 0, females = 0, total = 0)) %>%
-        tidytable::mutate.(og_m = og_males / sum(og_males),
-                          og_f = og_females / sum(og_females),
-                          og_t = og_total/sum(og_total),
-                          prop_m = males / sum(males),
-                          prop_f = females / sum(females),
-                          prop_t = total/sum(total),
-                          .by = c(year, species_code, stratum)) %>% 
-        tidytable::mutate.(ess_f = sum(prop_f * (1 - prop_f)) / sum((prop_f - og_f)^2),
-                          ess_m = sum(prop_m * (1 - prop_m)) / sum((prop_m - og_m)^2),
-                          ess_t = sum(prop_t * (1 - prop_t)) / sum((prop_t - og_t)^2),
-                          .by = c(year, species_code, stratum)) %>%
-        tidytable::pivot_longer.(cols = c(ess_f, ess_m, ess_t), names_to = "ess") %>%
-        tidytable::mutate.(in_out = ifelse(is.infinite(value), "out", "in")) %>%
-        tidytable::distinct(year, species_code, stratum, ess, value, in_out) 
-   
-  } else {
-    
-    sim_data %>% 
-        tidytable::mutate.(total = unsexed + males + females) %>% 
-        tidytable::full_join.(og) %>% 
-        tidytable::replace_na(list(og_unsexed = 0, og_males = 0, og_females = 0, og_total = 0, 
-                                  unsexed = 0, males = 0, females = 0, total = 0)) %>%
-        tidytable::mutate.(og_m = og_males / sum(og_males),
-                          og_f = og_females / sum(og_females),
-                          og_t = og_total/sum(og_total),
-                          prop_m = males / sum(males),
-                          prop_f = females / sum(females),
-                          prop_t = total/sum(total),
-                          .by = c(year, species_code)) %>% 
-        tidytable::mutate.(ess_f = sum(prop_f * (1 - prop_f)) / sum((prop_f - og_f)^2),
-                          ess_m = sum(prop_m * (1 - prop_m)) / sum((prop_m - og_m)^2),
-                          ess_t = sum(prop_t * (1 - prop_t)) / sum((prop_t - og_t)^2),
-                          .by = c(year, species_code)) %>%
-        tidytable::pivot_longer.(cols = c(ess_f, ess_m, ess_t), names_to = "ess") %>%
-        tidytable::mutate.(in_out = ifelse(is.infinite(value), "out", "in")) %>%
-        tidytable::distinct(year, species_code, ess, value, in_out)
- 
-  }
+  
+  sim_data %>% 
+    tidytable::mutate.(total = unsexed + males + females) %>% 
+    tidytable::full_join.(og) %>% 
+    tidytable::drop_na() %>% 
+    tidytable::replace_na(list(og_unsexed = 0, og_males = 0, og_females = 0, og_total = 0, 
+                               unsexed = 0, males = 0, females = 0, total = 0)) %>%
+    tidytable::mutate.(og_m = og_males / sum(og_males),
+                       og_f = og_females / sum(og_females),
+                       og_t = og_total/sum(og_total),
+                       prop_m = males / sum(males),
+                       prop_f = females / sum(females),
+                       prop_t = total/sum(total),
+                       .by = c(year, species_code, type)) %>% 
+    tidytable::mutate.(ess_f = sum(prop_f * (1 - prop_f)) / sum((prop_f - og_f)^2),
+                       ess_m = sum(prop_m * (1 - prop_m)) / sum((prop_m - og_m)^2),
+                       ess_t = sum(prop_t * (1 - prop_t)) / sum((prop_t - og_t)^2),
+                       .by = c(year, species_code, type)) %>%
+    tidytable::pivot_longer.(cols = c(ess_f, ess_m, ess_t), names_to = "ess") %>%
+    tidytable::distinct(year, species_code, type, ess, value)
   
 }

--- a/R/lcomp.R
+++ b/R/lcomp.R
@@ -9,12 +9,12 @@
 lcomp <- function(lfreq_un) {
   lfreq_un %>%
     tidytable::summarise.(frequency = .N,
-                          .by = c(year, species_code, stratum, hauljoin, sex, length)) %>% 
+                          .by = c(year, species_code, stratum, hauljoin, sex, length, type)) %>% 
     tidytable::mutate.(nhauls = data.table::uniqueN(hauljoin),
-                       .by = c(year, species_code, stratum)) %>%
+                       .by = c(year, species_code, stratum, type)) %>%
     tidytable::mutate.(tot = sum(frequency),
-                       .by = c(year, species_code, stratum, hauljoin)) %>%
+                       .by = c(year, species_code, stratum, hauljoin, type)) %>%
     tidytable::summarise.(comp = sum(frequency) / mean(tot),
                           nhauls = mean(nhauls),
-                          .by = c(year, species_code, stratum, hauljoin, sex, length))
+                          .by = c(year, species_code, stratum, hauljoin, sex, length, type))
 }

--- a/R/swo.R
+++ b/R/swo.R
@@ -86,76 +86,64 @@ swo <- function(lfreq_data, specimen_data, cpue_data, strata_data, yrs,
   
   # randomize lengths ----
   if(isTRUE(boot_lengths)) {
-    boot_length(.lfreq_un) -> .lfreq_un
+    boot_length(.lfreq_un) %>% 
+      tidytable::mutate(type = 'base') -> .lfreq_un
+  } else{
+    .lfreq_un %>% 
+      tidytable::mutate(type = 'base') -> .lfreq_un
   }
   
   # reduce sex-specific length freq sample size (and move unselected samples to 'unsexed' category)
   if(!is.null(sexlen_samples)) {
     sample(.lfreq_un, samples = sexlen_samples) -> .out
     .lfreq_un_sub <- .out$data
+    .lfreq_un_sub %>% 
+      tidytable::mutate(type = 'sub') %>% 
+      tidytable::select(-id, -n) %>% 
+      tidytable::bind_rows(.lfreq_un) -> .lfreq_un
   }
   
   # reduce overall length freq sample sizes
   if(!is.null(length_samples)) {
     reduce_samples(.lfreq_un, samples = length_samples, type = 'length') -> .out
     .lfreq_un_sub <- .out$data
+    .lfreq_un_sub %>% 
+      tidytable::mutate(type = 'sub') %>% 
+      tidytable::select(-id) %>% 
+      tidytable::bind_rows(.lfreq_un) -> .lfreq_un
   }
   
   # length comp ----
-  if(!is.null(length_samples) | !is.null(sexlen_samples)) {
-    lcomp(.lfreq_un) -> .lcomp
-    lcomp(.lfreq_un_sub) -> .lcomp_sub
-  } else{
-    lcomp(.lfreq_un) -> .lcomp
-  }
+  lcomp(.lfreq_un) -> .lcomp
   
   # length population ----
-  if(!is.null(length_samples) | !is.null(sexlen_samples)) {
-    lpop(.lcomp, .cpue, .lngs) -> .lpop
-    lpop(.lcomp_sub, .cpue, .lngs) -> .lpop_sub
-  }else{
-    lpop(.lcomp, .cpue, .lngs) -> .lpop
-  }
-    
+  lpop(.lcomp, .cpue, .lngs) -> .lpop
+  
   # randomize age ----
   if(isTRUE(boot_ages)) {
-    boot_age(.agedat) -> .agedat
+    boot_age(.agedat) %>% 
+      tidytable::mutate(type = 'base') -> .agedat
+  } else{
+    .agedat %>% 
+      tidytable::mutate(type = 'base') -> .agedat
   }
   
   # reduce overall age sample sizes
   if(!is.null(age_samples)) {
     reduce_samples(.agedat, samples = age_samples, type = 'age') -> .out
     .agedat_sub <- .out$data
+    .agedat_sub  %>% 
+      tidytable::mutate(type = 'sub') %>% 
+      tidytable::select(-id) %>% 
+      tidytable::bind_rows(.agedat) -> .agedat
   }
   
   # age population ----
   
   # age pop'n with length subsampling
-  if(!is.null(length_samples) | !is.null(sexlen_samples)) {
-    apop(.lpop, .agedat, strata = strata) -> .apop
-    apop(.lpop_sub, .agedat, strata = strata) -> .apop_sub
-  }
-  
-  # age pop'n with age subsampling
-  if(!is.null(age_samples)) {
-    apop(.lpop, .agedat, strata = strata) -> .apop
-    apop(.lpop, .agedat_sub, strata = strata) -> .apop_sub
-  }
-  
-  # age pop'n with no length or age subsampling
-  if(is.null(length_samples) & is.null(sexlen_samples) & is.null(age_samples)){
-    apop(.lpop, .agedat, strata = strata) -> .apop
-  }
+  apop(.lpop, .agedat, strata = strata) -> .apop
   
   # list results ----
-  
-  # with length subsampling
-  if(!is.null(length_samples) | !is.null(sexlen_samples)) { # with length subsampling
-    list(age = .apop, age_sub = .apop_sub, length = .lpop, length_sub = .lpop_sub, nosamp = .out$nosamp)
-  } else if(!is.null(age_samples)) { # with age subsampling
-    list(age = .apop, age_sub = .apop_sub, length = .lpop, nosamp = .out$nosamp)
-  } else if(is.null(length_samples) & is.null(sexlen_samples) & is.null(age_samples)){ # with no subsamplinng
-    list(age = .apop, length = .lpop)
-  }
+  list(age = .apop, length = .lpop)
   
 }

--- a/R/swo_sim.R
+++ b/R/swo_sim.R
@@ -46,8 +46,10 @@ swo_sim <- function(iters = 1, lfreq_data, specimen_data, cpue_data, strata_data
             cpue_data = cpue_data, strata_data = strata_data, yrs = yrs, strata = strata,
             boot_hauls = FALSE, boot_lengths = FALSE, boot_ages = FALSE,
             length_samples = NULL, age_samples = NULL, sexlen_samples = NULL)
-  oga <- og$age
-  ogl <- og$length
+  oga <- og$age %>% 
+    select(-type)
+  ogl <- og$length %>% 
+    select(-type)
   
   # run iterations
   rr <- purrr::map(1:iters, ~ swo(lfreq_data = lfreq_data, 
@@ -65,145 +67,59 @@ swo_sim <- function(iters = 1, lfreq_data, specimen_data, cpue_data, strata_data
   r_age <- do.call(mapply, c(list, rr, SIMPLIFY = FALSE))$age
   r_length <- do.call(mapply, c(list, rr, SIMPLIFY = FALSE))$length 
   
-  if(!is.null(length_samples) | !is.null(sexlen_samples)){
-    r_age_sub <- do.call(mapply, c(list, rr, SIMPLIFY = FALSE))$age_sub
-    r_length_sub <- do.call(mapply, c(list, rr, SIMPLIFY = FALSE))$length_sub
-  }
-  if(!is.null(age_samples)){
-    r_age_sub <- do.call(mapply, c(list, rr, SIMPLIFY = FALSE))$age_sub
-  }
-
-  # write out intermediate results
-  if(isTRUE(write_interm)) {
-    vroom::vroom_write(oga, file = here::here("output", region, paste0(save, "_orig_age.csv")), delim = ",")
-    vroom::vroom_write(ogl, file = here::here("output", region, paste0(save, "_orig_length.csv")), delim = ",")
-    r_age %>%
-      tidytable::map_df.(., ~as.data.frame(.x), .id = "sim") %>% 
-      vroom::vroom_write(here::here("output", region, paste0("base_", save, "_comp_age.csv")), delim = ",")
-    r_length %>%
-      tidytable::map_df.(., ~as.data.frame(.x), .id = "sim") %>% 
-      vroom::vroom_write(here::here("output", region, paste0("base_", save, "_comp_size.csv")), delim = ",")
-    if(!is.null(length_samples) | !is.null(sexlen_samples)){
-      r_age_sub %>%
-        tidytable::map_df.(., ~as.data.frame(.x), .id = "sim") %>% 
-        vroom::vroom_write(here::here("output", region, paste0(save, "_comp_age.csv")), delim = ",")
-      r_length_sub %>%
-        tidytable::map_df.(., ~as.data.frame(.x), .id = "sim") %>% 
-        vroom::vroom_write(here::here("output", region, paste0(save, "_comp_size.csv")), delim = ",")
-    }
-    if(!is.null(age_samples)){
-      r_age_sub %>%
-        tidytable::map_df.(., ~as.data.frame(.x), .id = "sim") %>% 
-        vroom::vroom_write(here::here("output", region, paste0(save, "_comp_age.csv")), delim = ",")
-    }
-  }
-  if(isTRUE(write_interm) & (!is.null(length_samples) | !is.null(sexlen_samples))) {
-    do.call(mapply, c(list, rr, SIMPLIFY = FALSE))$nosamp %>%
-      tidytable::map_df.(., ~as.data.frame(.x), .id = "sim") %>% 
-      vroom::vroom_write(here::here("output", region, paste0(save, "_removed_length.csv")), delim = ",")
-  }
+  # write out intermediate results - not saving for now, leaving og as example
+  # vroom::vroom_write(oga, file = here::here("output", region, paste0(save, "_orig_age.csv")), delim = ",")
+  # vroom::vroom_write(ogl, file = here::here("output", region, paste0(save, "_orig_length.csv")), delim = ",")
   
   # ess of bootstrapped age/length
   r_age %>%
-    tidytable::map.(., ~ess_age(sim_data = .x, og_data = oga, strata = strata)) %>%
+    tidytable::map.(., ~ess_age(sim_data = .x, og_data = oga)) %>%
     tidytable::map_df.(., ~as.data.frame(.x), .id = "sim") %>% 
-    tidytable::mutate.(comp_type = tidytable::case_when(ess == 'ess_f' ~ 'female',
-                                                        ess == 'ess_m' ~ 'male',
-                                                        ess == 'ess_t' ~ 'total')) %>% 
-    tidytable::rename(ess_base = 'value') %>% 
-    tidytable::select(sim, year, species_code, comp_type, ess_base) -> ess_ag
+    tidytable::rename(comp_type = ess) %>% 
+    tidytable::mutate.(comp_type = tidytable::case_when(comp_type == 'ess_f' ~ 'female',
+                                                        comp_type == 'ess_m' ~ 'male',
+                                                        comp_type == 'ess_t' ~ 'total')) -> ess_age
   r_length %>%
-    tidytable::map.(., ~ess_size(sim_data = .x, og_data = ogl, strata = strata)) %>%
+    tidytable::map.(., ~ess_size(sim_data = .x, og_data = ogl)) %>%
     tidytable::map_df.(., ~as.data.frame(.x), .id = "sim") %>% 
-    tidytable::mutate.(comp_type = tidytable::case_when(ess == 'ess_f' ~ 'female',
-                                                        ess == 'ess_m' ~ 'male',
-                                                        ess == 'ess_t' ~ 'total')) %>% 
-    tidytable::rename(ess_base = 'value') %>% 
-    tidytable::select(sim, year, species_code, comp_type, ess_base) -> ess_sz
+    tidytable::rename(comp_type = ess) %>% 
+    tidytable::mutate.(comp_type = tidytable::case_when(comp_type == 'ess_f' ~ 'female',
+                                                        comp_type == 'ess_m' ~ 'male',
+                                                        comp_type == 'ess_t' ~ 'total')) -> ess_size
   
-  ess_ag %>% 
-    tidytable::summarise(iss_base = psych::harmonic.mean(ess_base, na.rm=T),
-                         .by = c(year, species_code, comp_type)) %>% 
-    tidytable::filter.(iss_base > 0) -> iss_age
+  ess_age %>% 
+    tidytable::summarise(iss = psych::harmonic.mean(value, na.rm=T),
+                         .by = c(year, species_code, comp_type, type)) %>% 
+    tidytable::filter.(iss > 0) %>% 
+    tidytable::pivot_wider(names_from = type, values_from = iss) -> iss_age
   
-  ess_sz %>%
-    tidytable::summarise(iss_base = psych::harmonic.mean(ess_base, na.rm=T),
-                         .by = c(year, species_code, comp_type)) %>% 
-    tidytable::filter.(iss_base > 0) -> iss_size
+  ess_age %>%
+    tidytable::pivot_wider(names_from = type, values_from = value) -> ess_age
   
-  if(!is.null(length_samples) | !is.null(sexlen_samples)){
-    r_age_sub %>%
-      tidytable::map.(., ~ess_age(sim_data = .x, og_data = oga, strata = strata)) %>%
-      tidytable::map_df.(., ~as.data.frame(.x), .id = "sim") %>% 
-      tidytable::mutate.(comp_type = tidytable::case_when(ess == 'ess_f' ~ 'female',
-                                                          ess == 'ess_m' ~ 'male',
-                                                          ess == 'ess_t' ~ 'total')) %>% 
-      tidytable::rename(ess_sub = 'value') %>% 
-      tidytable::select(sim, year, species_code, comp_type, ess_sub) %>% 
-      tidytable::left_join(ess_ag) -> ess_age_sub
-    
-    r_length_sub %>%
-      tidytable::map.(., ~ess_size(sim_data = .x, og_data = ogl, strata = strata)) %>%
-      tidytable::map_df.(., ~as.data.frame(.x), .id = "sim") %>% 
-      tidytable::mutate.(comp_type = tidytable::case_when(ess == 'ess_f' ~ 'female',
-                                                          ess == 'ess_m' ~ 'male',
-                                                          ess == 'ess_t' ~ 'total')) %>% 
-      tidytable::rename(ess_sub = 'value') %>% 
-      tidytable::select(sim, year, species_code, comp_type, ess_sub) %>% 
-      tidytable::left_join(ess_sz) -> ess_size_sub
-    
-    ess_age_sub %>% 
-      tidytable::summarise(iss_sub = psych::harmonic.mean(ess_sub, na.rm=T),
-                           iss_base = psych::harmonic.mean(ess_base, na.rm=T),
-                           .by = c(year, species_code, comp_type)) -> iss_age_sub
-    
-    ess_size_sub %>% 
-      tidytable::summarise(iss_sub = psych::harmonic.mean(ess_sub, na.rm=T),
-                           iss_base = psych::harmonic.mean(ess_base, na.rm=T),
-                           .by = c(year, species_code, comp_type)) -> iss_size_sub
-  }
+  ess_size %>% 
+    tidytable::summarise(iss = psych::harmonic.mean(value, na.rm=T),
+                         .by = c(year, species_code, comp_type, type)) %>% 
+    tidytable::filter.(iss > 0) %>% 
+    tidytable::pivot_wider(names_from = type, values_from = iss) -> iss_size
   
-  if(!is.null(age_samples)){
-    r_age_sub %>%
-      tidytable::map.(., ~ess_age(sim_data = .x, og_data = oga, strata = strata)) %>%
-      tidytable::map_df.(., ~as.data.frame(.x), .id = "sim") %>% 
-      tidytable::mutate.(comp_type = tidytable::case_when(ess == 'ess_f' ~ 'female',
-                                                          ess == 'ess_m' ~ 'male',
-                                                          ess == 'ess_t' ~ 'total')) %>% 
-      tidytable::rename(ess_sub = 'value') %>% 
-      tidytable::select(sim, year, species_code, comp_type, ess_sub) %>% 
-      tidytable::left_join(ess_ag) -> ess_age_sub
-
-    ess_age_sub %>% 
-      tidytable::summarise(iss_sub = psych::harmonic.mean(ess_sub, na.rm=T),
-                           iss_base = psych::harmonic.mean(ess_base, na.rm=T),
-                           .by = c(year, species_code, comp_type)) -> iss_age_sub
-  }
+  ess_size %>%
+    tidytable::pivot_wider(names_from = type, values_from = value) -> ess_size
   
   # write out ess/iss results
-  if(!is.null(save) & (!is.null(length_samples) | !is.null(sexlen_samples))){
-    vroom::vroom_write(ess_age_sub, 
+  if(!is.null(save)){
+    vroom::vroom_write(ess_age, 
                        here::here("output", region, paste0(save, "_ess_ag.csv")), 
                        delim = ",")
-    vroom::vroom_write(ess_size_sub, 
+    vroom::vroom_write(iss_age, 
+                       here::here("output", region, paste0(save, "_iss_ag.csv")), 
+                       delim = ",")
+    vroom::vroom_write(ess_size, 
                        here::here("output", region, paste0(save, "_ess_sz.csv")), 
                        delim = ",")
-    
-    vroom::vroom_write(iss_age_sub, 
-                       here::here("output", region, paste0(save, "_iss_ag.csv")), 
-                       delim = ",")
-    vroom::vroom_write(iss_size_sub, 
+    vroom::vroom_write(iss_size, 
                        here::here("output", region, paste0(save, "_iss_sz.csv")), 
                        delim = ",")
+    
   }
   
-  if(!is.null(age_samples)){
-    vroom::vroom_write(ess_age_sub, 
-                       here::here("output", region, paste0(save, "_ess_ag.csv")), 
-                       delim = ",")
-    
-    vroom::vroom_write(iss_age_sub, 
-                       here::here("output", region, paste0(save, "_iss_ag.csv")), 
-                       delim = ",")
-  }
 }


### PR DESCRIPTION
so, while that haul issue was there, it wasn't the end of the story... turns out, you need to hold onto the results from the full dataset in order to properly compare with the subsampled dataset rather than run the base case and all the individual cases and then compare back to the base cases. here's a plot of what happens:

![sep_vs_nest](https://user-images.githubusercontent.com/5578975/222304281-7ae319e5-2a39-40f4-a94a-3947c2222ee1.png)

here 'nest' means we nest the base with the subsample case in the same run, and 'stand' is our standard way of doing it where we do the base and subsample runs separately. i'm still not completely sure why having them run separate doesn't work, but holding onto the iterations 'full data' and then the 'subsampled data' to compare directly gives the correct results. this involves a somewhat fundamental change, in that we won't necessarily be able to use swo to just run the full data case, it will always be run with a subsampling case. but, that's what we have surveyISS for i guess. i also involves some changes to how the output looks, but i did that cause i've been joining the base and subsample cases after the fact, figured it'd be easier to just do that in the package (and cuts down on the amount of results that get written out)